### PR TITLE
Removed const from non-const behaviour function

### DIFF
--- a/src/lbsolver/LBrheology.h
+++ b/src/lbsolver/LBrheology.h
@@ -44,7 +44,7 @@ public:
     inline lbBase_t tau() const {
         return tau_;
     }
-    inline lbBase_t tau(const lbBase_t& tauIn) const {
+    inline lbBase_t tau(const lbBase_t& tauIn) {
       tau_=tauIn;
       return tau_;
     }


### PR DESCRIPTION
Just a minor fix, because technically it's not const (No clue why it was working at all).
Removed a single const declaration from a function which has a non-const operation.